### PR TITLE
Add JavaFX interface for Gob language

### DIFF
--- a/gob-fx/pom.xml
+++ b/gob-fx/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.kq.amqp</groupId>
+        <artifactId>gob-mvn</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.kq.gob.fx</groupId>
+    <artifactId>gob-fx</artifactId>
+    <name>Gob JavaFX</name>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <javafx.version>21.0.2</javafx.version>
+        <!-- Detect platform to pull in the correct JavaFX natives -->
+        <javafx.platform>${javafx.platform}</javafx.platform>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.kq.gob</groupId>
+            <artifactId>gob</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+            <classifier>${javafx.platform}</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>0.0.8</version>
+                <configuration>
+                    <mainClass>com.kq.gob.fx.GobFxApp</mainClass>
+                    <!-- configure a launcher name so jpackage creates an executable -->
+                    <launcher>gob-fx</launcher>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gob-fx/src/main/java/com/kq/gob/fx/GobFxApp.java
+++ b/gob-fx/src/main/java/com/kq/gob/fx/GobFxApp.java
@@ -1,0 +1,59 @@
+package com.kq.gob.fx;
+
+import com.kq.gob.Gob.Gob;
+import javafx.application.Application;
+import javafx.geometry.Insets;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.SplitPane;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+/**
+ * Simple JavaFX front end for the Gob language.
+ * The application allows entering source code and executing it
+ * by calling the core {@link Gob#run(String)} interpreter.
+ *
+ * Run the UI with the JavaFX Maven plugin:
+ *     mvn -pl gob-fx javafx:run
+ *
+ * Package the application into a native executable with:
+ *     mvn -pl gob-fx javafx:jpackage
+*/
+public class GobFxApp extends Application {
+
+    @Override
+    public void start(Stage stage) {
+        TextArea codeArea = new TextArea();
+        codeArea.setPromptText("Enter Gob code...");
+
+        TextArea outputArea = new TextArea();
+        outputArea.setEditable(false);
+        outputArea.setPromptText("Output...");
+
+        Button runButton = new Button("Run");
+        runButton.setOnAction(e -> {
+            String source = codeArea.getText();
+            String result = Gob.run(source);
+            outputArea.setText(result);
+        });
+
+        SplitPane splitPane = new SplitPane(codeArea, outputArea);
+        splitPane.setDividerPositions(0.5);
+
+        BorderPane root = new BorderPane();
+        root.setCenter(splitPane);
+        BorderPane.setMargin(runButton, new Insets(5));
+        root.setBottom(runButton);
+
+        Scene scene = new Scene(root, 800, 600);
+        stage.setTitle("Gob Interpreter");
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <modules>
         <module>gob</module>
         <module>gob-web</module>
+        <module>gob-fx</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary
- add `gob-fx` module with a JavaFX UI that runs Gob code
- wire the parent pom to include the new module and configure JavaFX plugin for packaging
- configure platform-specific JavaFX dependencies so the UI can be packaged as a native executable

## Testing
- `mvn -q -pl gob-fx -am package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9948d1e8833097abff7a5753bd0f